### PR TITLE
Add paginated access to children of nodes

### DIFF
--- a/src/cript/_client.py
+++ b/src/cript/_client.py
@@ -49,6 +49,7 @@ class Cript(SyncAPIClient):
     schema: resources.SchemaResource
     nodes: resources.NodesResource
     search: resources.SearchResource
+    _child: resources.child.ChildResource
     controlled_vocabularies: resources.ControlledVocabulariesResource
     with_raw_response: CriptWithRawResponse
     with_streaming_response: CriptWithStreamedResponse
@@ -110,6 +111,7 @@ class Cript(SyncAPIClient):
         self.schema = resources.SchemaResource(self)
         self.nodes = resources.NodesResource(self)
         self.search = resources.SearchResource(self)
+        self._child = resources.child.ChildResource(self)
         self.controlled_vocabularies = resources.ControlledVocabulariesResource(self)
         self.with_raw_response = CriptWithRawResponse(self)
         self.with_streaming_response = CriptWithStreamedResponse(self)

--- a/src/cript/nodes/main.py
+++ b/src/cript/nodes/main.py
@@ -220,7 +220,7 @@ class CriptNode(dict):
         try:
             return self.__getitem__(key)
         except KeyError:
-            print("\nchild debug\n", self.children)
+            # TODO consider a caching of these paginators
             if key in self.children:
                 child_paginator = cript.resources.child.ChildPaginator(self, key)
                 return child_paginator

--- a/src/cript/nodes/main.py
+++ b/src/cript/nodes/main.py
@@ -7,8 +7,10 @@ from jsonschema.validators import validator_for
 from jsonschema.exceptions import best_match
 from uuid import uuid4
 
+import cript
 from cript import Cript, NotFoundError, camel_case_to_snake_case, extract_node_from_result
 from .schema import cript_schema
+
 
 logger = logging.getLogger(__name__)
 
@@ -218,7 +220,12 @@ class CriptNode(dict):
         try:
             return self.__getitem__(key)
         except KeyError:
-            raise AttributeError(key)
+            print("\nchild debug\n", self.children)
+            if key in self.children:
+                child_paginator = cript.resources.child.ChildPaginator(self, key)
+                return child_paginator
+            else:
+                raise AttributeError(key)
 
     def __setattr__(self, key, value):
         self.__setitem__(key, value)

--- a/src/cript/resources/__init__.py
+++ b/src/cript/resources/__init__.py
@@ -33,6 +33,12 @@ from .controlled_vocabularies import (
     AsyncControlledVocabulariesResourceWithStreamingResponse,
 )
 
+from .child import (
+    ChildResource,
+    ChildResourceWithRawResponse,
+    ChildResourceWithStreamingResponse,
+)
+
 __all__ = [
     "SchemaResource",
     "AsyncSchemaResource",
@@ -58,4 +64,7 @@ __all__ = [
     "AsyncControlledVocabulariesResourceWithRawResponse",
     "ControlledVocabulariesResourceWithStreamingResponse",
     "AsyncControlledVocabulariesResourceWithStreamingResponse",
+    "ChildResource",
+    "ChildResourceWithRawResponse",
+    "ChildResourceWithStreamingResponse",
 ]

--- a/src/cript/resources/child.py
+++ b/src/cript/resources/child.py
@@ -1,0 +1,149 @@
+import httpx
+from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
+from .._utils import (
+    maybe_transform,
+    async_maybe_transform,
+)
+from .._compat import cached_property
+from .._response import (
+    to_raw_response_wrapper,
+    to_streamed_response_wrapper,
+    async_to_raw_response_wrapper,
+    async_to_streamed_response_wrapper,
+)
+from .._base_client import (
+    make_request_options,
+)
+from ..types.shared.search import Search
+from .._resource import SyncAPIResource
+
+class ChildPaginator:
+    # TODO consider writing operations
+    def __init__(self, parent, child, client=None):
+        if client is None:
+            client = parent.client
+        self._client = client
+        self._parent = parent
+        self._child = child
+
+        self._current_child_list = []
+        self._current_child_position = 0
+        self._current_page = 0
+        self._count = None
+
+    def __iter__(self):
+        self._current_child_position = 0
+        return self
+
+    def __next__(self):
+        if self._current_child_position >= len(self._current_child_list):
+            self._fetch_next_page()
+        try:
+            next_node = self._current_child_list[self._current_child_position]
+        except IndexError:
+            raise StopIteration
+
+        self._current_child_position += 1
+
+        return next_node
+
+    def _fetch_next_page(self):
+        if self._finished_fetching:
+            raise StopIteration
+
+        response = self._client._child.child(self._parent, self._child, self._current_page)
+        self._current_page += 1
+        if self._count is not None and self._count != int(response.data.count):
+            raise RuntimeError("The number of elements for a child iteration changed during pagination. This may lead to inconsistencies. Please try again.")
+        self._count = int(response.data.count)
+
+        self._current_child_list += response.data.result
+
+    # Make it a random access iterator, since ppl expect it to behave list a list
+    def __getitem__(self, key):
+        key_index = int(key)
+        previous_pos = self._current_child_position
+        try:
+            if key_index < 0:
+                while not self._finished_fetching:
+                    next(self)
+
+            while len(self._current_child_list) <= key_index:
+                try:
+                    next(self)
+                except StopIteration:
+                    break
+        finally:
+            self._current_child_position = previous_pos
+        # We don't need explicit bounds checking, since the list access does that for us.
+        return self._current_child_list[key_index]
+
+    def __len__(self):
+        previous_pos = self._current_child_position
+        try:
+            if self._count is None:
+                try:
+                    next(iter(self))
+                except StopIteration:
+                    self._count = 0
+        finally:
+            self._current_child_position = previous_pos
+        return self._count
+
+    @property
+    def _finished_fetching(self):
+        if self._count is None:
+            return False
+        return len(self._current_child_list) == self._count
+
+
+class ChildResource(SyncAPIResource):
+    @cached_property
+    def with_raw_response(self):
+        return ChildResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self):
+        return ChildResourceWithStreamingResponse(self)
+
+    def child(
+            self,
+            parent,
+            child: str,
+            page: int,
+            *,
+            extra_headers: Headers | None = None,
+            extra_query: Query | None = None,
+            extra_body: Body | None = None,
+            timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> Search:
+        """
+        Obtain all children of parent node.
+
+        Args:
+          parent: parent node
+          child: attribute name of the child node
+        """
+        return self._get(f"/{parent.name_url}/{parent.uuid}/{child}",
+                         options=make_request_options(
+                             extra_headers=extra_headers,
+                             extra_query=extra_query,
+                             extra_body=extra_body,
+                             query={"page": page},
+                             timeout=timeout,
+                         ),
+                         cast_to=Search,
+                         )
+
+
+class ChildResourceWithRawResponse:
+    def __init__(self, child:ChildResource) -> None:
+        self._child = child
+
+        self.node = to_raw_response_wrapper(child.node)
+
+class ChildResourceWithStreamingResponse:
+    def __init__(self, child:ChildResource) -> None:
+        self._child = child
+
+        self.node = to_streamed_response_wrapper(child.node)

--- a/tests/api_resources/test_cript.py
+++ b/tests/api_resources/test_cript.py
@@ -261,7 +261,7 @@ class TestCript:
             material_list += [mat1]
         proj1 = Project(uuid=CREATED_UUID, material=material_list)
 
-        paginator_iter = cript.resources.child.ChildPaginator(proj1, "material")
+        paginator_iter = proj1.material
         for i, child in enumerate(paginator_iter):
             assert child.get("name").endswith(f"#{i}")
 

--- a/tests/api_resources/test_cript.py
+++ b/tests/api_resources/test_cript.py
@@ -67,6 +67,9 @@ class TestCript:
         col1 = Collection(name=generic_collection, experiment=[exp1])
         proj1 = Project(uuid=CREATED_UUID, collection=[col1])
         assert exp1.get("name") == generic_experiment
+        assert proj1.collection[0].get("name") == col1.name
+        # TODO full node access
+        # assert proj1.collection[0].experiment[0].name == exp1.name
 
 
     def test_create_material(self) -> None:
@@ -298,6 +301,11 @@ class TestCript:
         # Test empty paginator
         paginator_empty = cript.resources.child.ChildPaginator(proj1, "inventory")
         assert len(paginator_empty) == 0
+
+        # Test empty paginator
+        paginator_non_exist = cript.resources.child.ChildPaginator(proj1, "non-existent attribute")
+        with pytest.raises(cript.NotFoundError):
+            len(paginator_non_exist)
 
     def test_delete_node(self) -> None:
         proj1 = Project(uuid=CREATED_UUID)


### PR DESCRIPTION
Before this PR it was not possible to access children attributes of nodes.

After this PR it should be possible to access any children nodes with a paginated access.

# Notes
This adds a resource to the SDK that allows the API call to find all children of a node.
I only implemented the `Sync` version of this access.
And oriented myself on the `search` resource.
It seems to work, but I hope I got the design right.

# Tests

Added a new test that extensively tests the capabilities of the child pagination.
Extended some of the existing tests to use children access instead of `get`.

# TODO before PR gets merged

[] return not a list of dicts, but a list of node objects
@brili can you help me of how to convert the dictionaries, I get from search result into nodes?
[x] consider caching the child paginators
At the moment, every time a user accesses a child attribute a new child paginator is created.
That works fine, but isn't efficient with many attribute calls.

We could store the child paginators in the class. Like so:
```python
            # TODO consider a caching of these paginators
            if key in self.children:
                child_paginator = cript.resources.child.ChildPaginator(self, key)
                
                ###
                self.__dict__[key] = child_paginator
                ###
                
                return child_paginator
            else:
                raise AttributeError(key)
 ```
 This would work, because on repeated access the attribute exists now.
 
I didn't just want to add them as attributes right now, because I wasn't sure how to avoid possible async between the child attributs in the paginator and the objects in `children` attribute.

[] Also, I am not sure if this works for children that are present on CRIPT, but not necessarily in python.
Mainly is this line
```python
if key in self.children:
```
correct?
I expect it to be `True` if `key` is a possible child attribute, and to be `False` else.
But does the node always know all its possible children attributes or only the locally established ones?
 
 

# TODO not included in this PR
Consider writing access.
What should the behavior be if someone modifies an attribute of a node.
For example, if I add a material to an existing python project like
```python
proj1.material += [new_material_node]
```

I think the behavior should ultimately be, that the new node gets added to the project, and saved into CRIPT.
And should work for all sub-node types, not just `project` and `material`
That does not happen at the moment.
In fact, this may end in undesired behavior right now without error.


@brili 
Thank you I appreciate your insights.