### PR TITLE
Remove proxies setting from http client

### DIFF
--- a/src/cript/_base_client.py
+++ b/src/cript/_base_client.py
@@ -833,7 +833,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             base_url=base_url,
             # cast to a valid type because mypy doesn't understand our type narrowing
             timeout=cast(Timeout, timeout),
-            proxies=proxies,
+            #proxies=proxies,
             transport=transport,
             limits=limits,
             follow_redirects=True,


### PR DESCRIPTION
Fixes that are needed to get this going again.

These changes are neither pretty not good, but they make it work again.